### PR TITLE
Fix publishAllPublicationsToMavenCentralRepository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: 'zulu'
           java-version: 21
       - name: Publish to MavenCentral
-        run: ./gradlew :fhir-path:publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
**Old**:
./gradlew :fhir-path:publishAllPublicationsToMavenCentralRepository

**New**:
./gradlew publishAllPublicationsToMavenCentralRepository


The old command was scoped to the :fhir-path module, fine when that was the only artifact. But now, a release is five artifacts: fhir-path-core, fhir-path-r4, fhir-path-r4b, fhir-path-r5, and the fhir-path aggregator that depends on the other four. 

Scoped to :fhir-path, the workflow only uploads the aggregator and never publishes the four modules it depends on, it's an incomplete deployment.