### PR TITLE
Fix StackOverflowError in generated complex-type property dispatch

### DIFF
--- a/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/FhirModelHelperGenerationTask.kt
+++ b/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/FhirModelHelperGenerationTask.kt
@@ -18,6 +18,7 @@ package dev.ohs.fhir.fhirpath.codegen.model
 
 import dev.ohs.fhir.fhirpath.codegen.model.schema.StructureDefinition
 import dev.ohs.fhir.fhirpath.codegen.model.schema.StructureDefinition.Kind
+import dev.ohs.fhir.fhirpath.codegen.model.schema.sortedByInheritanceDepthDescending
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -142,7 +143,8 @@ abstract class FhirModelHelperGenerationTask : DefaultTask() {
         structureDefinitions =
           structureDefinitions
             .filter { it.kind == Kind.COMPLEX_TYPE }
-            .filterNot { it.name == "Element" },
+            .filterNot { it.name == "Element" }
+            .sortedByInheritanceDepthDescending(),
       )
       .writeTo(outputDir)
 

--- a/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/ModelExtensionFileSpecGenerator.kt
+++ b/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/ModelExtensionFileSpecGenerator.kt
@@ -114,7 +114,7 @@ object ModelExtensionFileSpecGenerator {
               .beginControlFlow("return when(name)")
               .apply {
                 for (element in backboneElement.value) {
-                  addStatement("%S -> %N", element.getElementName(), element.getElementName())
+                  addStatement("%S -> this.%N", element.getElementName(), element.getElementName())
                 }
                 addStatement("else -> error(\"\$name is not a valid property name\")")
               }

--- a/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/schema/MoreStructureDefinitions.kt
+++ b/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/schema/MoreStructureDefinitions.kt
@@ -32,3 +32,37 @@ val StructureDefinition.backboneElements
           }
         }
     } ?: emptyMap()
+
+/**
+ * Sorts so that subtypes always appear before their ancestors (e.g. `HumanName` before `Element`
+ * before `Base`).
+ *
+ * Generators that emit a single `when(this) { is X -> ...; is Y -> ... }` dispatcher over a flat
+ * list of [StructureDefinition]s rely on the FIRST matching `is` branch. If an ancestor type (e.g.
+ * `Base`, which every FHIR type derives from) is listed before one of its subtypes, the ancestor's
+ * branch silently shadows the subtype's branch for every instance of that subtype, since the
+ * subtype also satisfies `is <ancestor>`. Sorting by descending inheritance depth (most-derived
+ * first) guarantees a type's own branch is always checked before any of its ancestors' branches,
+ * regardless of the arbitrary order structure definition files were read from disk.
+ */
+fun List<StructureDefinition>.sortedByInheritanceDepthDescending(): List<StructureDefinition> {
+  val baseNameByName = associate { it.name to it.baseDefinition?.substringAfterLast('/') }
+  val depthByName = mutableMapOf<String, Int>()
+  val inProgress = mutableSetOf<String>()
+
+  fun depthOf(name: String): Int {
+    depthByName[name]?.let {
+      return it
+    }
+    check(inProgress.add(name)) {
+      "Cycle detected while computing inheritance depth for structure definition '$name'"
+    }
+    val baseName = baseNameByName[name]
+    val depth = if (baseName == null || baseName == name) 0 else 1 + depthOf(baseName)
+    inProgress.remove(name)
+    depthByName[name] = depth
+    return depth
+  }
+
+  return sortedByDescending { depthOf(it.name) }
+}

--- a/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/schema/MoreStructureDefinitions.kt
+++ b/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/schema/MoreStructureDefinitions.kt
@@ -34,16 +34,20 @@ val StructureDefinition.backboneElements
     } ?: emptyMap()
 
 /**
- * Sorts so that subtypes always appear before their ancestors (e.g. `HumanName` before `Element`
- * before `Base`).
+ * Sorts subtypes before their ancestors (e.g. `HumanName` before `Element` before `Base`). Apply
+ * this to the type list before generating type dispatchers, so every instance matches its own
+ * type's branch instead of an ancestor's.
  *
- * Generators that emit a single `when(this) { is X -> ...; is Y -> ... }` dispatcher over a flat
- * list of [StructureDefinition]s rely on the FIRST matching `is` branch. If an ancestor type (e.g.
- * `Base`, which every FHIR type derives from) is listed before one of its subtypes, the ancestor's
- * branch silently shadows the subtype's branch for every instance of that subtype, since the
- * subtype also satisfies `is <ancestor>`. Sorting by descending inheritance depth (most-derived
- * first) guarantees a type's own branch is always checked before any of its ancestors' branches,
- * regardless of the arbitrary order structure definition files were read from disk.
+ * The generated `Element.getProperty()` / `hasProperty()` / `getAllChildren()` helpers check types
+ * in this list's order, like `when(this) { is HumanName -> ...; is Element -> ... }`, and `when`
+ * picks the first matching branch.
+ *
+ * Without this sort, the list keeps the arbitrary order the files were read from disk, so an
+ * ancestor like `Base` can end up listed first. A `HumanName` is also a `Base`, so it matches the
+ * ancestor's branch, which calls the same helper again, recursing until a StackOverflowError.
+ *
+ * With this sort, each type's own branch always comes before its ancestors' branches, so every
+ * instance is dispatched to its own type.
  */
 fun List<StructureDefinition>.sortedByInheritanceDepthDescending(): List<StructureDefinition> {
   val baseNameByName = associate { it.name to it.baseDefinition?.substringAfterLast('/') }

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/R5ComplexTypeDispatchRegressionTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/R5ComplexTypeDispatchRegressionTest.kt
@@ -195,4 +195,18 @@ class R5ComplexTypeDispatchRegressionTest {
 
     assertTrue(descendants.size > 50, "expected a deep tree, got ${descendants.size} nodes")
   }
+
+  @Test
+  fun `backbone element properties named 'name' are not shadowed by the lookup parameter`() {
+    // Regression test for a parameter-shadowing bug in `ModelExtensionFileSpecGenerator`: nested
+    // backbone-element `getProperty()` functions referenced element properties as a bare
+    // identifier (e.g. `"name" -> name`) instead of `this.name`. Since the lookup function's own
+    // parameter is also named `name`, any backbone element with a property literally called
+    // `name` (e.g. Patient.contact.name) resolved to the parameter itself, silently returning the
+    // string "name" instead of the actual field value.
+    val patient = loadPatient()
+
+    assertEquals(listOf("Bénédicte"), engine.evaluateExpression("contact.name.given", patient))
+    assertEquals(listOf("du Marché"), engine.evaluateExpression("contact.name.family", patient))
+  }
 }

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/R5ComplexTypeDispatchRegressionTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/R5ComplexTypeDispatchRegressionTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025-2026 Open Health Stack Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.ohs.fhir.fhirpath
+
+import dev.ohs.fhir.fhirpath.types.FhirPathDateTime
+import dev.ohs.fhir.model.r5.Resource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+private val jsonR5 = Json { ignoreUnknownKeys = true }
+
+private val engine = FhirPathEngine.forR5()
+
+// Deliberately touches many distinct FHIR complex types (HumanName, ContactPoint, Address,
+// Period, CodeableConcept, Coding, Attachment, Identifier, Reference, Meta) nested at varying
+// depths (including inside repeated BackboneElements), so evaluating expressions against it
+// exercises the generated `Element`/`BackboneElement`.getProperty()/hasProperty()/getAllChildren()
+// dispatchers for a broad cross section of types, not just one.
+private const val PATIENT_JSON =
+  """{
+  "resourceType": "Patient",
+  "id": "example",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2026-01-01T00:00:00Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:1.2.36.146.595.217.0.1",
+      "value": "12345",
+      "period": { "start": "2001-05-06" },
+      "assigner": { "reference": "Organization/1", "display": "Acme Healthcare" }
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Chalmers",
+      "given": ["Peter", "James"],
+      "period": { "start": "1974-12-25" }
+    }
+  ],
+  "telecom": [
+    { "system": "phone", "value": "(03) 5555 6473", "use": "work" }
+  ],
+  "gender": "male",
+  "birthDate": "1974-12-25",
+  "address": [
+    {
+      "use": "home",
+      "line": ["534 Erewhon St"],
+      "city": "PleasantVille",
+      "state": "Vic",
+      "postalCode": "3999",
+      "period": { "start": "1974-12-25", "end": "2002-01-01" }
+    }
+  ],
+  "maritalStatus": {
+    "coding": [
+      { "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus", "code": "M", "display": "Married" }
+    ],
+    "text": "Married"
+  },
+  "photo": [
+    { "contentType": "image/jpeg", "title": "Photo" }
+  ],
+  "contact": [
+    {
+      "relationship": [
+        { "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/v2-0131", "code": "N" }] }
+      ],
+      "name": { "family": "du Marché", "given": ["Bénédicte"] },
+      "telecom": [{ "system": "phone", "value": "+33 (237) 998327" }],
+      "address": {
+        "line": ["534 Erewhon St"],
+        "city": "PleasantVille",
+        "period": { "start": "2010-01-01" }
+      },
+      "gender": "female",
+      "organization": { "reference": "Organization/1", "display": "Acme Healthcare" },
+      "period": { "start": "2012-01-01" }
+    }
+  ],
+  "communication": [
+    {
+      "language": {
+        "coding": [{ "system": "urn:ietf:bcp:47", "code": "en", "display": "English" }]
+      },
+      "preferred": true
+    }
+  ],
+  "generalPractitioner": [
+    { "reference": "Practitioner/example" }
+  ],
+  "managingOrganization": { "reference": "Organization/1" },
+  "link": [
+    { "other": { "reference": "Patient/example2" }, "type": "seealso" }
+  ]
+}"""
+
+private fun loadPatient(): Resource = jsonR5.decodeFromString(PATIENT_JSON)
+
+/**
+ * Regression tests for the StackOverflowError previously thrown when the generated
+ * `Element`/`BackboneElement`/`Resource` `getProperty()`/`hasProperty()`/`getAllChildren()`
+ * dispatchers checked an ancestor type (e.g. `Base`) before one of its own subtypes, causing
+ * every instance of that subtype (e.g. `HumanName`) to match the ancestor's `when` branch and
+ * recurse into itself forever. See commit that added
+ * `sortedByInheritanceDepthDescending()` in `MoreStructureDefinitions.kt`.
+ */
+class R5ComplexTypeDispatchRegressionTest {
+
+  @Test
+  fun `evaluating property paths across many complex types does not stack overflow`() {
+    val patient = loadPatient()
+
+    assertEquals(listOf("Peter", "James"), engine.evaluateExpression("name.given", patient))
+    assertEquals(listOf("Chalmers"), engine.evaluateExpression("name.family", patient))
+    assertEquals(listOf("(03) 5555 6473"), engine.evaluateExpression("telecom.value", patient))
+    assertEquals(listOf("PleasantVille"), engine.evaluateExpression("address.city", patient))
+    assertEquals(
+      FhirPathDateTime(year = 2002, month = 1, day = 1),
+      engine.evaluateExpression("address.period.end", patient).single(),
+    )
+    assertEquals(listOf("M"), engine.evaluateExpression("maritalStatus.coding.code", patient))
+    assertEquals(
+      listOf("+33 (237) 998327"),
+      engine.evaluateExpression("contact.telecom.value", patient),
+    )
+    assertEquals(
+      listOf("PleasantVille"),
+      engine.evaluateExpression("contact.address.city", patient),
+    )
+    assertEquals(
+      listOf("N"),
+      engine.evaluateExpression("contact.relationship.coding.code", patient),
+    )
+    assertEquals(
+      listOf("Organization/1"),
+      engine.evaluateExpression("contact.organization.reference", patient),
+    )
+    assertEquals(listOf("12345"), engine.evaluateExpression("identifier.value", patient))
+    assertEquals(
+      listOf("Organization/1"),
+      engine.evaluateExpression("identifier.assigner.reference", patient),
+    )
+    assertEquals(listOf("image/jpeg"), engine.evaluateExpression("photo.contentType", patient))
+    assertEquals(
+      listOf("en"),
+      engine.evaluateExpression("communication.language.coding.code", patient),
+    )
+    assertEquals(
+      listOf("Practitioner/example"),
+      engine.evaluateExpression("generalPractitioner.reference", patient),
+    )
+    assertEquals(
+      listOf("Organization/1"),
+      engine.evaluateExpression("managingOrganization.reference", patient),
+    )
+    assertEquals(
+      listOf("Patient/example2"),
+      engine.evaluateExpression("link.other.reference", patient),
+    )
+    assertEquals(listOf("1"), engine.evaluateExpression("meta.versionId", patient))
+  }
+
+  @Test
+  fun `walking the entire resource tree does not stack overflow`() {
+    val patient = loadPatient()
+
+    // descendants() recursively calls getAllChildren() on every element in the tree, so it
+    // exercises the generated dispatchers for every complex type actually present in this
+    // resource (HumanName, ContactPoint, Address, Period, CodeableConcept, Coding, Attachment,
+    // Identifier, Reference, Meta, and the BackboneElements nested inside `contact`,
+    // `communication` and `link`), regardless of which specific type the bug happens to hit.
+    val descendants = engine.evaluateExpression("descendants()", patient)
+
+    assertTrue(descendants.size > 50, "expected a deep tree, got ${descendants.size} nodes")
+  }
+}

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/R5ComplexTypeDispatchRegressionTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/R5ComplexTypeDispatchRegressionTest.kt
@@ -27,11 +27,8 @@ private val jsonR5 = Json { ignoreUnknownKeys = true }
 
 private val engine = FhirPathEngine.forR5()
 
-// Deliberately touches many distinct FHIR complex types (HumanName, ContactPoint, Address,
-// Period, CodeableConcept, Coding, Attachment, Identifier, Reference, Meta) nested at varying
-// depths (including inside repeated BackboneElements), so evaluating expressions against it
-// exercises the generated `Element`/`BackboneElement`.getProperty()/hasProperty()/getAllChildren()
-// dispatchers for a broad cross section of types, not just one.
+// Touches many complex types, including some nested inside repeated BackboneElements, so the
+// tests below exercise generated property dispatch broadly rather than for a single type.
 private const val PATIENT_JSON =
   """{
   "resourceType": "Patient",
@@ -119,17 +116,16 @@ private const val PATIENT_JSON =
 private fun loadPatient(): Resource = jsonR5.decodeFromString(PATIENT_JSON)
 
 /**
- * Regression tests for the StackOverflowError previously thrown when the generated
- * `Element`/`BackboneElement`/`Resource` `getProperty()`/`hasProperty()`/`getAllChildren()`
- * dispatchers checked an ancestor type (e.g. `Base`) before one of its own subtypes, causing
- * every instance of that subtype (e.g. `HumanName`) to match the ancestor's `when` branch and
- * recurse into itself forever. See commit that added
- * `sortedByInheritanceDepthDescending()` in `MoreStructureDefinitions.kt`.
+ * Regression tests for two bugs that made evaluating ordinary FHIRPath expressions against an R5
+ * `Patient` unreliable: one crashed the app outright, the other silently handed back the wrong
+ * data. Both traced back to bugs in generated property-lookup code.
  */
 class R5ComplexTypeDispatchRegressionTest {
 
   @Test
   fun `evaluating property paths across many complex types does not stack overflow`() {
+    // Before the fix, an app calling evaluateExpression("name.given", ...) would crash with a
+    // StackOverflowError instead of getting the given names back.
     val patient = loadPatient()
 
     assertEquals(listOf("Peter", "James"), engine.evaluateExpression("name.given", patient))
@@ -186,11 +182,9 @@ class R5ComplexTypeDispatchRegressionTest {
   fun `walking the entire resource tree does not stack overflow`() {
     val patient = loadPatient()
 
-    // descendants() recursively calls getAllChildren() on every element in the tree, so it
-    // exercises the generated dispatchers for every complex type actually present in this
-    // resource (HumanName, ContactPoint, Address, Period, CodeableConcept, Coding, Attachment,
-    // Identifier, Reference, Meta, and the BackboneElements nested inside `contact`,
-    // `communication` and `link`), regardless of which specific type the bug happens to hit.
+    // Which property type actually crashed depended on arbitrary codegen ordering, so it wasn't
+    // just HumanName at risk. descendants() touches every element in the resource, so this one
+    // call would have crashed no matter which type the bug happened to land on.
     val descendants = engine.evaluateExpression("descendants()", patient)
 
     assertTrue(descendants.size > 50, "expected a deep tree, got ${descendants.size} nodes")
@@ -198,12 +192,9 @@ class R5ComplexTypeDispatchRegressionTest {
 
   @Test
   fun `backbone element properties named 'name' are not shadowed by the lookup parameter`() {
-    // Regression test for a parameter-shadowing bug in `ModelExtensionFileSpecGenerator`: nested
-    // backbone-element `getProperty()` functions referenced element properties as a bare
-    // identifier (e.g. `"name" -> name`) instead of `this.name`. Since the lookup function's own
-    // parameter is also named `name`, any backbone element with a property literally called
-    // `name` (e.g. Patient.contact.name) resolved to the parameter itself, silently returning the
-    // string "name" instead of the actual field value.
+    // A different, quieter bug: an app reading contact.name.given got back an empty list, no
+    // error at all, because generated code confused the "name" property with the "name" of the
+    // property it was looking up.
     val patient = loadPatient()
 
     assertEquals(listOf("Bénédicte"), engine.evaluateExpression("contact.name.given", patient))


### PR DESCRIPTION
Closes #75 

Adds List<StructureDefinition>.sortedByInheritanceDepthDescending() (buildSrc/.../schema/MoreStructureDefinitions.kt), which walks each type's baseDefinition chain to compute its inheritance depth and sorts most-derived types first. FhirModelHelperGenerationTask now applies this sort to the complex-type list before handing it to ComplexTypeExtensionFileSpecGenerator, so a type's own `is` branch is always emitted - and therefore checked - before any of its ancestors' branches, regardless of on-disk file order.