### PR TITLE
Implement strict mode for property access

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,13 +262,13 @@ Any other values are invalid precision values and will throw an error if passed 
 
 ### Error handling
 
-The FHIRPath specification
-[does not specify](https://hl7.org/fhirpath/N1/#type-safety-and-strict-evaluation) the desired
-behavior when type checking errors occur, allowing the implementation to adopt a strict (e.g. throws
-an exception) or a lenient (e.g. returns an empty collection) approach. However, the
-[official test suite](https://github.com/FHIR/fhir-test-cases) include test cases that require
-lenient type checking. To accommodate such cases, this implementation returns an empty collection
-when the FHIRPath expression attempts to access a data element that does not exist.
+Whilst this library does not perform compile-time type checking discussed in the
+[specification](https://hl7.org/fhirpath/N1/#type-safety-and-strict-evaluation), it supports two
+run-time property access modes:
+
+* **Lenient mode (default):** Returns an empty collection (`{}`) when accessing an undefined
+  property.
+* **Strict mode:** Throws an `IllegalStateException` when accessing an undefined property.
 
 ## Conformance
 
@@ -295,6 +295,8 @@ documented in the table below.
 | `testPlusDate21`                   | Specification/Test |     |                                                        | As `testPlusDate13`.                                                                                                                                                                                   |
 | `testPlusDate22`                   | Specification/Test |     |                                                        | As `testPlusDate13`.                                                                                                                                                                                   |
 | `testMinus5`                       | Specification/Test |     |                                                        | As `testPlusDate13`.                                                                                                                                                                                   |
+| `testDollarOrderNotAllowed`        | Implementation     |     |                                                        | Ordered function validation not implemented. Test expects error when using `skip()` on unordered collection (`children()`), but engine does not track collection ordering.                             |
+| `testPolymorphicsB`                | Test               |     |                                                        | Test case expects output in lenient mode for invalid property navigation.                                                                                                                              |
 | `testType22`                       | Implementation     |     |                                                        | `is` with an unknown `System` type should evaluate to false, but the type resolver throws.                                                                                                             |
 | `testTypeA*`                       | Implementation     |     |                                                        | Evaluating `Parameters.parameter[x].value` crashes with `NoSuchElementException`.                                                                                                                      |
 | `testConformsTo*`                  | Implementation     |     |                                                        | Function `conformsTo` is not implemented.                                                                                                                                                              |
@@ -378,10 +380,21 @@ dependencies {
 }
 ```
 
+### Creating FHIRPath engine
+
+Create a `FhirPathEngine` for the FHIR version you are working with (R4, R4B, or R5):
+
+```kotlin
+// Create an engine for FHIR R4
+val fhirPathEngine = FhirPathEngine.forR4()
+
+// Create an engine with strict mode enabled (throws on invalid property access)
+val fhirPathEngineStrict = FhirPathEngine.forR4(strictMode = true)
+```
+
 ### Evaluating FHIRPath expressions
 
-To evaluate a FHIRPath expression, create a `FhirPathEngine` for the FHIR version you are working
-with and use the `evaluateExpression` function. Here is an example targeting FHIR R4:
+Use `evaluateExpression` API to evaluate FHIRPath expressions against a FHIR resource:
 
 ```kotlin
 import dev.ohs.fhir.fhirpath.FhirPathEngine
@@ -392,12 +405,13 @@ val patientExampleJson = ... // Load "patient-example.json"
 val json = Json { ignoreUnknownKeys = true }
 val patient = json.decodeFromString<Patient>(patientExampleJson)
 
-// Create the R4 evaluator engine
 val fhirPathEngine = FhirPathEngine.forR4()
-
-// Evaluate expressions
 val results = fhirPathEngine.evaluateExpression("name.given", patient)
 // ["Peter", "James", "Jim", "Peter", "James"]
+
+// In strict mode, accessing an unrecognized property throws an IllegalStateException
+val fhirPathEngineStrict = FhirPathEngine.forR4(strictMode = true)
+strictEngine.evaluateExpression("name.given1", patient) // Throws IllegalStateException
 ```
 
 ## Developer Guide

--- a/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/FhirModelHelperGenerationTask.kt
+++ b/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/FhirModelHelperGenerationTask.kt
@@ -136,27 +136,22 @@ abstract class FhirModelHelperGenerationTask : DefaultTask() {
       )
       .writeTo(outputDir)
 
-    // Generate extension functions for complex types.
+    // Generate extension functions for complex and primitive types.
     //
     // Abstract base complex types are filtered out because:
     // 1. An `is Base` branch inside `Element.getProperty(name)` recursively calls
-    // `Element.getProperty(name)`, causing a `StackOverflowError` (see
-    // https://github.com/ohs-foundation/kotlin-fhirpath/issues/75).
-    // 2. An `is DataType` branch would invoke `DataType.getProperty()`, which only handles `id` and
-    // `extension`, skipping the subtype's own properties.
+    //    `Element.getProperty(name)`, causing a StackOverflowError (see #75).
+    // 2. An `is DataType` branch would invoke `DataType.getProperty()`, which only handles `id`
+    //    and `extension`, skipping the subtype's specific properties.
     //
     // We keep `BackboneElement` because resource backbone elements (e.g. `Patient.Contact`)
     // delegate to `MoreBackboneElements.kt` via `is BackboneElement -> getProperty(name)`.
     //
-    // The only concrete subtype inheritance in FHIR involves `Age`, `Count`, `Distance`, and
-    // `Duration` inheriting from `Quantity`. These types share the same properties, therefore do
-    // not
-    // need to be treated differently in the context of these extension functions.
-    //
-    // Primitive types are also included so that their `id` and `extension` are navigable, e.g.
-    // `Patient.birthDate.extension(...)`. Dispatch order among primitives does not matter: a
-    // `code` picked up by its base type `string` still resolves the same `id`, `extension` and
-    // `value`.
+    // Subtype inheritance for concrete types requires no special handling:
+    // - Primitive subtypes (e.g. `code` extending `string`) matched by a base type branch still
+    // resolve the same `id`, `extension`, and `value`.
+    // - Complex `Quantity` subtypes (`Age`, `Count`, `Distance`, `Duration`) matched by a base type
+    // branch still resolve the same `value`, `unit`, `system`, `code`, and `comparator`.
 
     val abstractBaseComplexTypes =
       setOf("Element", "Base", "DataType", "BackboneType", "PrimitiveType")

--- a/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngine.kt
+++ b/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngine.kt
@@ -27,11 +27,13 @@ import org.antlr.v4.kotlinruntime.Token
 
 class FhirPathEngine(
   private val fhirPathTypeResolver: FhirPathTypeResolver,
-  fhirModelNavigator: FhirModelNavigator,
+  val fhirModelNavigator: FhirModelNavigator,
+  val strictMode: Boolean = false,
 ) {
-  private val evaluator = FhirPathEvaluator(fhirPathTypeResolver, fhirModelNavigator)
+  private val evaluator = FhirPathEvaluator(fhirPathTypeResolver, fhirModelNavigator, strictMode)
 
-  val traces: Map<String, List<TraceEntry>> get() = evaluator.traces
+  val traces: Map<String, List<TraceEntry>>
+    get() = evaluator.traces
 
   /**
    * Evaluates a FHIRPath expression against a single FHIR resource.

--- a/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEvaluator.kt
+++ b/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEvaluator.kt
@@ -65,6 +65,7 @@ data class TraceEntry(val value: Any, val path: String)
 internal class FhirPathEvaluator(
   val fhirPathTypeResolver: FhirPathTypeResolver,
   val fhirModelNavigator: FhirModelNavigator,
+  val strictMode: Boolean = false,
 ) : fhirpathBaseVisitor<Collection<Any>>() {
   private var resource: Any? = null
   private val contextStack = ArrayDeque<Collection<Any>>()
@@ -385,7 +386,10 @@ internal class FhirPathEvaluator(
       }
 
     return context.flatMap { item ->
-      when (val fieldValue = fhirModelNavigator.accessProperty(item, memberName)) {
+      when (
+        val fieldValue =
+          fhirModelNavigator.accessProperty(item, memberName, strictMode = strictMode)
+      ) {
         null -> emptyList()
         is List<*> -> fieldValue as Collection<Any>
         else -> listOf(fieldValue)

--- a/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/functions/FirstOrderFunctions.kt
+++ b/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/functions/FirstOrderFunctions.kt
@@ -130,10 +130,6 @@ internal fun Collection<Any>.invoke(
     "children" -> this.children(fhirModelNavigator)
     "descendants" -> this.descendants(fhirModelNavigator)
 
-    // FHIR-specific functions
-    // https://hl7.org/fhir/fhirpath.html#functions
-    "extension" -> this.extension(params, fhirModelNavigator)
-
     // Utility functions
     // https://hl7.org/fhirpath/N1/#utility-functions
     "now" -> now(now)
@@ -151,6 +147,10 @@ internal fun Collection<Any>.invoke(
     // Defined as a boolean logic operator in the specification, but the grammar handles this as a
     // function invocation.
     "not" -> this.not()
+
+    // FHIR-specific functions
+    // https://hl7.org/fhir/fhirpath.html#functions
+    "extension" -> this.extension(params, fhirModelNavigator)
 
     else -> error("Function '$functionName' is not implemented.")
   }

--- a/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/model/FhirModelNavigator.kt
+++ b/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/model/FhirModelNavigator.kt
@@ -25,7 +25,7 @@ import dev.ohs.fhir.fhirpath.types.TypeInfo
 internal const val STRICT_MODE = false
 
 abstract class FhirModelNavigator {
-  fun accessProperty(obj: Any, propertyName: String): Any? {
+  fun accessProperty(obj: Any, propertyName: String, strictMode: Boolean = false): Any? {
     // Ad-hoc handling for TypeInfo reflection properties (.namespace, .name, .baseType)
     if (obj is TypeInfo) {
       return when (propertyName) {
@@ -35,9 +35,12 @@ abstract class FhirModelNavigator {
         else -> null
       }
     }
-    if (!STRICT_MODE) {
-      // Allow graceful handling of invalid property access (returns null instead of throwing)
-      if (!hasProperty(obj, propertyName)) return null
+
+    if (!hasProperty(obj, propertyName)) {
+      if (strictMode) {
+        error("Property '$propertyName' does not exist on type '${obj::class.simpleName}'")
+      }
+      return null
     }
 
     val element = getProperty(obj, propertyName)

--- a/fhir-path-r4/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineR4.kt
+++ b/fhir-path-r4/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineR4.kt
@@ -19,9 +19,10 @@ package dev.ohs.fhir.fhirpath
 import dev.ohs.fhir.fhirpath.model.FhirR4ModelNavigator
 import dev.ohs.fhir.fhirpath.types.FhirR4TypeResolver
 
-fun FhirPathEngine.Companion.forR4(): FhirPathEngine {
+fun FhirPathEngine.Companion.forR4(strictMode: Boolean = false): FhirPathEngine {
   return FhirPathEngine(
     fhirPathTypeResolver = FhirR4TypeResolver,
     fhirModelNavigator = FhirR4ModelNavigator,
+    strictMode = strictMode,
   )
 }

--- a/fhir-path-r4b/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineR4B.kt
+++ b/fhir-path-r4b/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineR4B.kt
@@ -19,9 +19,10 @@ package dev.ohs.fhir.fhirpath
 import dev.ohs.fhir.fhirpath.model.FhirR4BModelNavigator
 import dev.ohs.fhir.fhirpath.types.FhirR4BTypeResolver
 
-fun FhirPathEngine.Companion.forR4B(): FhirPathEngine {
+fun FhirPathEngine.Companion.forR4B(strictMode: Boolean = false): FhirPathEngine {
   return FhirPathEngine(
     fhirPathTypeResolver = FhirR4BTypeResolver,
     fhirModelNavigator = FhirR4BModelNavigator,
+    strictMode = strictMode,
   )
 }

--- a/fhir-path-r5/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineR5.kt
+++ b/fhir-path-r5/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineR5.kt
@@ -19,9 +19,10 @@ package dev.ohs.fhir.fhirpath
 import dev.ohs.fhir.fhirpath.model.FhirR5ModelNavigator
 import dev.ohs.fhir.fhirpath.types.FhirR5TypeResolver
 
-fun FhirPathEngine.Companion.forR5(): FhirPathEngine {
+fun FhirPathEngine.Companion.forR5(strictMode: Boolean = false): FhirPathEngine {
   return FhirPathEngine(
     fhirPathTypeResolver = FhirR5TypeResolver,
     fhirModelNavigator = FhirR5ModelNavigator,
+    strictMode = strictMode,
   )
 }

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngineTest.kt
@@ -36,6 +36,7 @@ private const val TEST_INPUT_DIR = "${TEST_RESOURCE_DIR}/resources"
 private val jsonR4 = Json { ignoreUnknownKeys = true }
 
 private val fhirPathEngine = FhirPathEngine.forR4()
+private val fhirPathEngineStrict = FhirPathEngine.forR4(strictMode = true)
 
 /**
  * A map from the test group name to the reason why the test group is skipped.
@@ -56,7 +57,6 @@ val skippedTestGroupToReasonMap =
  */
 val skippedTestCaseToReasonMap =
   mapOf(
-    "testPolymorphismB" to "Strict mode is not implemented yet",
     "testPolymorphismAsB" to
       "No error should be thrown according to https://hl7.org/fhirpath/#as-type-specifier",
     "testDateTimeGreaterThanDate1" to
@@ -85,8 +85,6 @@ val skippedTestCaseToReasonMap =
       "https://chat.fhir.org/#narrow/channel/179266-fhirpath/topic/Definite.20durations.20above.20seconds.20in.20date.20time.20arithmetic/with/564095766",
     "testDollarOrderNotAllowed" to
       "Ordered function validation not implemented. Test expects error when using skip() on unordered collection (children()), but engine does not track collection ordering.",
-    "testSimpleFail" to "Strict mode is not implemented yet",
-    "testSimpleWithWrongContext" to "Strict mode is not implemented yet",
     "testPolymorphicsB" to "Allow invalid test where it's not strict mode but expects output",
     "testIndex" to "TBD",
     "testPeriodInvariantOld" to "hasValue() is not implemented.",
@@ -142,16 +140,21 @@ class FhirPathEngineTest :
                 ?: Enabled.enabled
             }
           ) {
+            val engine =
+              if (testCase.mode == "strict" || testCase.expression.mode == "strict")
+                fhirPathEngineStrict
+              else fhirPathEngine
+
             if (testCase.expression.invalid != null) {
               assertFailsWith<Exception> {
-                fhirPathEngine.evaluateExpression(
+                engine.evaluateExpression(
                   testCase.expression.value,
                   testCase.inputfile?.let { inputMap[it] },
                 )
               }
             } else {
               val results =
-                fhirPathEngine.evaluateExpression(
+                engine.evaluateExpression(
                   testCase.expression.value,
                   testCase.inputfile?.let { inputMap[it] },
                 )

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirR4BModelNavigatorTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirR4BModelNavigatorTest.kt
@@ -46,9 +46,17 @@ class FhirR4BModelNavigatorTest {
   }
 
   @Test
-  fun `returns null for non existent property on resource`() {
+  fun `returns null for non existent property on resource in lenient mode`() {
     val patient = Patient(id = "p1")
     assertNull(FhirR4BModelNavigator.accessProperty(patient, "nonExistentProperty"))
+  }
+
+  @Test
+  fun `throws exception for non existent property on resource in strict mode`() {
+    val patient = Patient(id = "p1")
+    kotlin.test.assertFailsWith<IllegalStateException> {
+      FhirR4BModelNavigator.accessProperty(patient, "nonExistentProperty", strictMode = true)
+    }
   }
 
   @Test

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirR4ModelNavigatorTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirR4ModelNavigatorTest.kt
@@ -46,9 +46,17 @@ class FhirR4ModelNavigatorTest {
   }
 
   @Test
-  fun `returns null for non existent property on resource`() {
+  fun `returns null for non existent property on resource in lenient mode`() {
     val patient = Patient(id = "p1")
     assertNull(FhirR4ModelNavigator.accessProperty(patient, "nonExistentProperty"))
+  }
+
+  @Test
+  fun `throws exception for non existent property on resource in strict mode`() {
+    val patient = Patient(id = "p1")
+    kotlin.test.assertFailsWith<IllegalStateException> {
+      FhirR4ModelNavigator.accessProperty(patient, "nonExistentProperty", strictMode = true)
+    }
   }
 
   @Test

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirR5ModelNavigatorTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/FhirR5ModelNavigatorTest.kt
@@ -46,9 +46,17 @@ class FhirR5ModelNavigatorTest {
   }
 
   @Test
-  fun `returns null for non existent property on resource`() {
+  fun `returns null for non existent property on resource in lenient mode`() {
     val patient = Patient(id = "p1")
     assertNull(FhirR5ModelNavigator.accessProperty(patient, "nonExistentProperty"))
+  }
+
+  @Test
+  fun `throws exception for non existent property on resource in strict mode`() {
+    val patient = Patient(id = "p1")
+    kotlin.test.assertFailsWith<IllegalStateException> {
+      FhirR5ModelNavigator.accessProperty(patient, "nonExistentProperty", strictMode = true)
+    }
   }
 
   @Test


### PR DESCRIPTION
Re-enable `testPolymorphismB`, `testSimpleFail` and `testSimpleWithWrongContext` (all of which were missing in the exclusion table in the `README.md` file so no need to remove them).

Add missing test exclusions `testDollarOrderNotAllowed` and `testPolymorphicsB` introduced in #50 back to the `README.md` file.