### PR TITLE
Use lazy loading and relative path for project directory

### DIFF
--- a/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/FhirModelHelperGenerationTask.kt
+++ b/buildSrc/src/main/kotlin/dev/ohs/fhir/fhirpath/codegen/model/FhirModelHelperGenerationTask.kt
@@ -34,7 +34,7 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 abstract class FhirModelHelperGenerationTask : DefaultTask() {
   @get:InputFiles
-  @get:PathSensitive(PathSensitivity.NONE)
+  @get:PathSensitive(PathSensitivity.RELATIVE)
   // These are files retrieved from third_party/hl7.fhir.<R4|R4B|R5>.core directory
   abstract val corePackageFiles: ConfigurableFileCollection
 

--- a/fhir-path-r4/build.gradle.kts
+++ b/fhir-path-r4/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 val generateR4Helpers = tasks.register<FhirModelHelperGenerationTask>("generateR4Helpers") {
     description = "Generate FHIR model extensions for R4"
     this.corePackageFiles.from(
-        File(project.rootDir, "third_party/hl7.fhir.r4.core/package").listFiles()
+        layout.projectDirectory.dir("../third_party/hl7.fhir.r4.core/package")
     )
     this.fhirVersion.set("r4")
     outputDirectory.set(layout.buildDirectory.dir("generated/r4/kotlin"))

--- a/fhir-path-r4b/build.gradle.kts
+++ b/fhir-path-r4b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 val generateR4BHelpers = tasks.register<FhirModelHelperGenerationTask>("generateR4BHelpers") {
     description = "Generate FHIR model extensions for R4B"
     this.corePackageFiles.from(
-        File(project.rootDir, "third_party/hl7.fhir.r4b.core/package").listFiles()
+        layout.projectDirectory.dir("../third_party/hl7.fhir.r4b.core/package")
     )
     this.fhirVersion.set("r4b")
     outputDirectory.set(layout.buildDirectory.dir("generated/r4b/kotlin"))

--- a/fhir-path-r5/build.gradle.kts
+++ b/fhir-path-r5/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 val generateR5Helpers = tasks.register<FhirModelHelperGenerationTask>("generateR5Helpers") {
     description = "Generate FHIR model extensions for R5"
     this.corePackageFiles.from(
-        File(project.rootDir, "third_party/hl7.fhir.r5.core/package").listFiles()
+        layout.projectDirectory.dir("../third_party/hl7.fhir.r5.core/package")
     )
     this.fhirVersion.set("r5")
     outputDirectory.set(layout.buildDirectory.dir("generated/r5/kotlin"))


### PR DESCRIPTION
This avoids unnecessary file scanning during configuration phase as well as allowing relocatable caching for CI runners.