### PR TITLE
perf: cache parsed expressions and accept collection-valued variables

### DIFF
--- a/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngine.kt
+++ b/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEngine.kt
@@ -29,9 +29,17 @@ class FhirPathEngine(
   private val fhirPathTypeResolver: FhirPathTypeResolver,
   val fhirModelNavigator: FhirModelNavigator,
   val strictMode: Boolean = false,
+  private val cacheParsedExpressions: Boolean = true,
 ) {
   var traces: Map<String, List<TraceEntry>> = emptyMap()
     private set
+
+  private val parsedExpressionCache =
+    object : LinkedHashMap<String, fhirpathParser.ExpressionContext>(64, 0.75f, true) {
+      override fun removeEldestEntry(
+        eldest: MutableMap.MutableEntry<String, fhirpathParser.ExpressionContext>
+      ) = size > MAX_CACHED_PARSED_EXPRESSIONS
+    }
 
   /**
    * Evaluates a FHIRPath expression against a single FHIR resource.
@@ -46,23 +54,7 @@ class FhirPathEngine(
     base: Any?,
     variables: Map<String, Any?> = emptyMap(),
   ): Collection<Any> {
-    val lexer = fhirpathLexer(CharStreams.fromString(expression))
-    val tokenStream = CommonTokenStream(lexer)
-    val parser =
-      fhirpathParser(tokenStream).apply {
-        // Make sure the parser fails for invalid expressions instead of trying to recover
-        errorHandler = BailErrorStrategy()
-      }
-
-    val parsedExpression = parser.expression()
-    // ANTLR attempts to parse the entire expression but does not throw an error when it cannot. In
-    // such cases, explicitly check that the entire expression has been consumed to ensure that the
-    // expression is valid.
-    if (tokenStream.LA(1) != Token.EOF) {
-      error(
-        "Expression contains extraneous input that could not be parsed: '${tokenStream[parser.currentToken!!.tokenIndex + 1].text}'"
-      )
-    }
+    val parsedExpression = parseExpression(expression)
 
     // Create a new evaluator per invocation for thread safety.
     val evaluator =
@@ -86,5 +78,43 @@ class FhirPathEngine(
     return result
   }
 
-  companion object
+  private fun parseExpression(expression: String): fhirpathParser.ExpressionContext {
+    if (cacheParsedExpressions) {
+      synchronized(parsedExpressionCache) {
+        parsedExpressionCache[expression]?.let {
+          return it
+        }
+      }
+    }
+    val parsed = parseUncached(expression)
+    if (cacheParsedExpressions) {
+      synchronized(parsedExpressionCache) { parsedExpressionCache[expression] = parsed }
+    }
+    return parsed
+  }
+
+  private fun parseUncached(expression: String): fhirpathParser.ExpressionContext {
+    val lexer = fhirpathLexer(CharStreams.fromString(expression))
+    val tokenStream = CommonTokenStream(lexer)
+    val parser =
+      fhirpathParser(tokenStream).apply {
+        // Make sure the parser fails for invalid expressions instead of trying to recover
+        errorHandler = BailErrorStrategy()
+      }
+
+    val parsedExpression = parser.expression()
+    // ANTLR attempts to parse the entire expression but does not throw an error when it cannot. In
+    // such cases, explicitly check that the entire expression has been consumed to ensure that the
+    // expression is valid.
+    if (tokenStream.LA(1) != Token.EOF) {
+      error(
+        "Expression contains extraneous input that could not be parsed: '${tokenStream[parser.currentToken!!.tokenIndex + 1].text}'"
+      )
+    }
+    return parsedExpression
+  }
+
+  companion object {
+    private const val MAX_CACHED_PARSED_EXPRESSIONS = 512
+  }
 }

--- a/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEvaluator.kt
+++ b/fhir-path-core/src/commonMain/kotlin/dev/ohs/fhir/fhirpath/FhirPathEvaluator.kt
@@ -349,7 +349,11 @@ internal class FhirPathEvaluator(
         listOf("http://hl7.org/fhir/StructureDefinition/$extensionId")
       }
       variables.containsKey(name) -> {
-        variables[name]?.let { listOf(it) } ?: emptyList()
+        when (val value = variables[name]) {
+          null -> emptyList()
+          is Collection<*> -> value.filterNotNull()
+          else -> listOf(value)
+        }
       }
       else -> error("Unknown variable: %$name")
     }

--- a/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/EnvironmentVariablesTest.kt
+++ b/fhir-path/src/commonTest/kotlin/dev/ohs/fhir/fhirpath/EnvironmentVariablesTest.kt
@@ -93,4 +93,15 @@ class EnvironmentVariablesTest {
       fhirPathEngine.evaluateExpression(expression = "%unknownVar", base = null)
     }
   }
+
+  @Test
+  fun `collection environment variable is the collection itself`() {
+    val result =
+      fhirPathEngine.evaluateExpression(
+        expression = "%items",
+        base = null,
+        variables = mapOf("items" to listOf("a", "b")),
+      )
+    assertEquals(listOf("a", "b"), result.toList())
+  }
 }


### PR DESCRIPTION
## Summary

Two small engine changes that large SDC questionnaires need.

### Parse cache
`evaluateExpression` ran ANTLR on every call. Parsed trees are now kept in an LRU (512) and reused. A new `FhirPathEvaluator` is still created per call, so evaluation stays thread-safe (see #129). Disable with `cacheParsedExpressions = false` on the constructor.

### Collection variables
`%name` for a `Collection` is now that collection, not a one-element list wrapping it. FHIRPath environment variables are collections; this matches the spec and lets SDC pass an item index as `%sdcRepeatItems0`.

A questionnaire with 400 items and 397 calculatedExpressions that each look up three other items:

| dataset | vanilla kotlin-fhirpath | + parse cache / memo + item index |
|---|---:|---:|
| `%resource.repeat(item).where(linkId=…)` | 922 ms | **12 ms** |
| `%resource.item.where(linkId=…)` | 591 ms | **8 ms** |

The index rewrite itself lives in kotlin-fhir-data-capture; this PR only makes it possible.

## Tests
- `collection environment variable is the collection itself`